### PR TITLE
Patch to pass threescale info to the next filter in the chain

### DIFF
--- a/src/configuration/api/v1.rs
+++ b/src/configuration/api/v1.rs
@@ -9,6 +9,8 @@ pub struct Configuration {
     pub system: Option<System>,
     pub backend: Option<Backend>,
     pub services: Option<Vec<Service>>,
+    // pass request to the next filter in the chain
+    pub pass_request: Option<bool>,
 }
 
 impl Configuration {

--- a/src/proxy/authrep.rs
+++ b/src/proxy/authrep.rs
@@ -15,7 +15,7 @@ use threescalers::{
 };
 
 #[derive(Debug, thiserror::Error)]
-enum MatchError {
+pub enum MatchError {
     #[error("no known service matched")]
     NoServiceMatched,
     #[error("credentials error")]


### PR DESCRIPTION
This PR adds new configurable behavior to pass threescale's application to the next filter in the chain instead of doing an aurhrep call.  Please suggest any edits that you think should be made before merging this PR.